### PR TITLE
Paginated iterator now returns a modifiable list instead of an unmodifiable one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>mal4j</artifactId>
-    <version>2.9.1</version>
+    <version>2.10.0-SNAPSHOT</version>
 
     <profiles>
         <profile>

--- a/src/main/java/com/kttdevelopment/mal4j/PaginatedIterator.java
+++ b/src/main/java/com/kttdevelopment/mal4j/PaginatedIterator.java
@@ -26,7 +26,7 @@ import java.util.*;
  * @param <T> type
  *
  * @since 1.0.0
- * @version 1.1.1
+ * @version 2.10.0
  * @author Katsute
  */
 public abstract class PaginatedIterator<T> implements Iterator<T> {
@@ -58,7 +58,7 @@ public abstract class PaginatedIterator<T> implements Iterator<T> {
     /**
      * Returns if the response has a next page.
      *
-     * @return if next page
+     * @return if has next page
      *
      * @since 1.0.0
      */
@@ -92,7 +92,7 @@ public abstract class PaginatedIterator<T> implements Iterator<T> {
      * @since 1.0.0
      */
     public final List<T> toList(){
-        return Collections.unmodifiableList(list);
+        return new ArrayList<>(list);
     }
 
     /**
@@ -103,7 +103,7 @@ public abstract class PaginatedIterator<T> implements Iterator<T> {
      * @since 1.0.0
      */
     public final Set<T> toSet(){
-        return Collections.unmodifiableSet(new LinkedHashSet<>(list));
+        return new LinkedHashSet<>(list);
     }
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/TestIterator.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestIterator.java
@@ -25,6 +25,7 @@ final class TestIterator {
             .withLimit(100)
             .searchAll();
         assertNotEquals(0, iterator.toList().size());
+        assertNotEquals(0, iterator.toSet().size());
         assertEquals(TestProvider.AnimeID, iterator.toList().get(0).getID());
 
         final AnimePreview first = iterator.next();
@@ -38,6 +39,7 @@ final class TestIterator {
             .getForumTopicDetailPostQuery(481)
             .searchAll();
         assertNotEquals(0, iterator.toList().size());
+        assertNotEquals(0, iterator.toSet().size());
         assertEquals(481, iterator.toList().get(0).getForumTopicDetail().getID());
 
         iterator.forEachRemaining(post -> assertEquals(481, post.getForumTopicDetail().getID()));


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Made paginated iterator toList return a new list instead of an unmodifiable one.
 - Made paginated iterator toSet return a new set instead of an unmodifiable one.
 - Documentation changes.
 - Test changes.

[WF-2981809091](https://github.com/KatsuteDev/Mal4J/actions/runs/2981809091)