### PR TITLE
Removed deprecated enums

### DIFF
--- a/src/main/java/com/kttdevelopment/mal4j/anime/property/AnimeSource.java
+++ b/src/main/java/com/kttdevelopment/mal4j/anime/property/AnimeSource.java
@@ -27,7 +27,7 @@ import com.kttdevelopment.mal4j.property.FieldEnum;
  *
  * @see AnimePreview#getSource()
  * @since 1.0.0
- * @version 2.9.0
+ * @version 2.10.0
  * @author Katsute
  */
 @SuppressWarnings("SpellCheckingInspection")
@@ -39,17 +39,7 @@ public enum AnimeSource implements FieldEnum {
     Original        ("original"),
     Manga           ("manga"),
     FourKomaManga   ("4_koma_manga"),
-    /**
-     * @deprecated use {@link #WebManga}
-     */
-    @Deprecated
-    Web_Manga       ("web_manga"),
     WebManga        ("web_manga"),
-    /**
-     * @deprecated use {@link #DigitalManga}
-     */
-    @Deprecated
-    Digital_Manga   ("digital_manga"),
     DigitalManga    ("digital_manga"),
     Novel           ("novel"),
     LightNovel      ("light_novel"),
@@ -87,8 +77,7 @@ public enum AnimeSource implements FieldEnum {
     public static AnimeSource asEnum(final String string){
         if(string != null){
             for(final AnimeSource value : values())
-                if(!value.name().contains("_") && value.field.equalsIgnoreCase(string))
-                    return value;
+                return value;
             Logging.getLogger().warning(String.format("Unrecognized Anime source '%s', please report this to the maintainers of Mal4J", string));
         }
 

--- a/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaType.java
+++ b/src/main/java/com/kttdevelopment/mal4j/manga/property/MangaType.java
@@ -26,7 +26,7 @@ import com.kttdevelopment.mal4j.property.FieldEnum;
  *
  * @see com.kttdevelopment.mal4j.manga.MangaPreview#getType()
  * @since 1.0.0
- * @version 2.9.0
+ * @version 2.10.0
  * @author Katsute
  */
 @SuppressWarnings("SpellCheckingInspection")
@@ -35,11 +35,6 @@ public enum MangaType implements FieldEnum {
     Unknown     ("unknown"),
 
     Manga       ("manga"),
-    /**
-     * @deprecated use {@link #LightNovel}
-     */
-    @Deprecated
-    Novel       ("novel"),
     LightNovel  ("light_novel"),
     OneShot     ("one_shot"),
     Doujin      ("doujinshi"),

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -175,11 +175,11 @@ final class TestAnime {
         assertEquals(AnimeType.Unknown, AnimeType.asEnum("?"));
         assertEquals(RelationType.Unknown, RelationType.asEnum("?"));
 
-        assertEquals(AnimeSource.WebNovel, mal.getAnime(37208).getSource());
-        assertEquals(AnimeSource.MixedMedia, mal.getAnime(34474).getSource());
+        assertEquals(AnimeSource.WebNovel, mal.getAnime(37208).getSource(), "Unknown type: " + mal.getAnime(37208).getRawSource());
+        assertEquals(AnimeSource.MixedMedia, mal.getAnime(34474).getSource(), "Unknown type: " + mal.getAnime(34474).getRawSource());
 
         for(final RelatedAnime relatedAnime : mal.getAnime(16498).getRelatedAnime())
-            assertNotEquals(RelationType.Unknown, relatedAnime.getRelationType());
+            assertNotEquals(RelationType.Unknown, relatedAnime.getRelationType(), "Unknown type: " + relatedAnime.getRawRelationType());
     }
 
 }


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Removed AnimeSource.Web_Manga
 - Removed AnimeSource.Digital_Manga
 - Removed MangaType.Novel

#### Release Notes

 - Removed `AnimeSource.Web_Manga`, use `AnimeSource.WebManga`
 - Removed `AnimeSource.Digital_Manga`, use `AnimeSource.DigitalManga`
 - Removed `MangaType.Novel`, use `MangaType.LightNovel`