### PR TITLE
Remove deprecated authentication methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>mal4j</artifactId>
-    <version>2.10.0</version>
+    <version>2.11.0</version>
 
     <profiles>
         <profile>

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeList.java
@@ -44,7 +44,7 @@ import java.util.List;
  * </ul>
  *
  * @since 1.0.0
- * @version 2.10.0
+ * @version 2.11.0
  * @author Katsute
  */
 public abstract class MyAnimeList {
@@ -98,46 +98,6 @@ public abstract class MyAnimeList {
     }
 
     /**
-     * Creates an interface with an OAuth token. Note that this method does not support {@link #refreshToken()}.
-     *
-     * @deprecated this method has been renamed to {@link #withToken(String)} for simplicity
-     * @param token OAuth token, Ex: 'Bearer oauth2token'
-     * @return MyAnimeList
-     * @throws NullPointerException if token is null
-     * @throws InvalidTokenException if token doesn't start with 'Bearer'
-     *
-     * @see #withClientID(String)
-     * @see #withAuthorization(MyAnimeListAuthenticator)
-     * @see #withToken(String)
-     * @since 1.0.0
-     */
-    @Deprecated
-    public static MyAnimeList withOAuthToken(final String token){
-        Logging.getLogger().warning("The use of this method is deprecated, please use `MyAnimeList.withToken(...)");
-        return withToken(token);
-    }
-
-    /**
-     * Creates an interface with an authenticator.
-     *
-     * @deprecated this method has been renamed to {@link #withOAuth2(MyAnimeListAuthenticator)} to reduce confusion with {@link Authorization}
-     * @param authenticator authenticator
-     * @return MyAnimeList
-     * @throws NullPointerException if authenticator is null
-     *
-     * @see #withClientID(String)
-     * @see #withToken(String)
-     * @see #refreshToken()
-     * @see MyAnimeListAuthenticator
-     * @since 1.0.0
-     */
-    @Deprecated
-    public static MyAnimeList withAuthorization(final MyAnimeListAuthenticator authenticator){
-        Logging.getLogger().warning("The use of this method is deprecated, please use `MyAnimeList.withOAuth2(...)");
-        return withOAuth2(authenticator);
-    }
-
-    /**
      * Creates an interface using an authenticator.
      *
      * @param authenticator authenticator
@@ -162,18 +122,6 @@ public abstract class MyAnimeList {
      * @since 2.6.0
      */
     public abstract void refreshToken();
-
-    /**
-     * Refreshes the OAuth token. Only works with {@link #withAuthorization(MyAnimeListAuthenticator)}.
-     *
-     * @deprecated this method has been renamed to {@link #refreshToken()} for simplicity
-     * @throws UnsupportedOperationException if this wasn't created with an authenticator
-     *
-     * @since 1.0.0
-     * @see #refreshToken()
-     */
-    @Deprecated
-    public abstract void refreshOAuthToken();
 
 // experimental
 

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAuthenticator.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListAuthenticator.java
@@ -45,7 +45,7 @@ import static com.kttdevelopment.mal4j.Json.*;
  * </ul>
  *
  * @since 1.0.0
- * @version 2.7.0
+ * @version 2.11.0
  * @author Katsute
  */
 public final class MyAnimeListAuthenticator {
@@ -101,51 +101,6 @@ public final class MyAnimeListAuthenticator {
                 redirect_URI
             )
         );
-    }
-
-    /**
-     * Creates a MyAnimeListAuthenticator.
-     * <br>
-     * If you used a redirect URI to generate your authorization code you must use {@link #MyAnimeListAuthenticator(String, String, String, String, String)}.
-     *
-     * @deprecated use {@link #MyAnimeListAuthenticator(Authorization)}
-     * @param client_id client id
-     * @param client_secret client secret, null if application has none
-     * @param authorization_code authorization code (<b>not</b> your authorization URL)
-     * @param PKCE_code_challenge PKCE code challenge used to obtain authorization code. Must be between 43 and 128 characters.
-     * @throws InvalidTokenException if token is invalid or expired
-     *
-     * @see MyAnimeListAuthenticator#MyAnimeListAuthenticator(String, String, String, String, String)
-     * @see MyAnimeList#withAuthorization(MyAnimeListAuthenticator)
-     * @since 1.0.0
-     */
-    @SuppressWarnings("SpellCheckingInspection")
-    @Deprecated
-    public MyAnimeListAuthenticator(final String client_id, final String client_secret, final String authorization_code, final String PKCE_code_challenge){
-        this(new Authorization(client_id, client_secret, authorization_code, PKCE_code_challenge), null);
-        Logging.getLogger().warning("The use of this constuctor has been deprecated, please use `new MyAnimeListAuthenticator(new Authorization(...))`");
-    }
-
-    /**
-     * Creates a MyAnimeListAuthenticator.
-     *
-     * @deprecated use {@link #MyAnimeListAuthenticator(Authorization)}
-     * @param client_id client id
-     * @param client_secret client secret, null if application has none
-     * @param authorization_code authorization code (<b>not</b> your authorization URL)
-     * @param PKCE_code_challenge PKCE code challenge used to obtain authorization code. Must be between 43 and 128 characters.
-     * @param redirect_uri redirect URI, required if used to generate authorization_code
-     * @throws InvalidTokenException if token is invalid or expired
-     *
-     * @see MyAnimeListAuthenticator#MyAnimeListAuthenticator(String, String, String, String)
-     * @see MyAnimeList#withAuthorization(MyAnimeListAuthenticator)
-     * @since 2.5.0
-     */
-    @SuppressWarnings("SpellCheckingInspection")
-    @Deprecated
-    public MyAnimeListAuthenticator(final String client_id, final String client_secret, final String authorization_code, final String PKCE_code_challenge, final String redirect_uri){
-        this(new Authorization(client_id, client_secret, authorization_code, PKCE_code_challenge, redirect_uri), null);
-        Logging.getLogger().warning("The use of this constuctor has been deprecated, please use `new MyAnimeListAuthenticator(new Authorization(...))`");
     }
 
     /**

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -79,12 +79,6 @@ final class MyAnimeListImpl extends MyAnimeList {
         this.token = authenticator.refreshAccessToken().getToken();
     }
 
-    @Override @Deprecated
-    public synchronized final void refreshOAuthToken(){
-        Logging.getLogger().warning("The use of this method is deprecated, please use `refreshToken()");
-        refreshToken();
-    }
-
 // experimental features
 
     // features that are no longer experimental (make sure to deprecate)


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Removed deprecated auth methods

[WF-3107700449](https://github.com/KatsuteDev/Mal4J/actions/runs/3107700449)

#### Release Notes

* Removed `withOAuthToken`, use `withToken`
* Removed `refreshOAuthToken`, use `refreshToken`
* Removed `withAuthorization`, use `withOAuth2`
* The deprecated String parameter has been replaced with the Authorization parameter.
  Previously:
  ```java
  new MyAnimeListAuthenticator("client_id", "client_secret", "authorization_code", "PKCE_code_challenge");
  ```
  Should be replaced with:
   ```java
   new MyAnimeListAuthenticator(new Authorization("client_id", "client_secret", "authorization_code", "PKCE_code_challenge"));
   ```
   If you were not already using this new object before, an access token can be passed to this method to use an existing token, rather than generating a new one:
   ```java
   new MyAnimeListAuthenticator(new Authorization(...), new AccessToken("access_token");
   new MyAnimeListAuthenticator(new Authorization(...), new AccessToken("access_token", "refresh_token");
   new MyAnimeListAuthenticator(new Authorization(...), new AccessToken("access_token", "refresh_token", 1640995200);
   ```