### PR TITLE
Using experimental features without enabling them will now throw an exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>mal4j</artifactId>
-    <version>2.10.0</version>
+    <version>2.11.0</version>
 
     <profiles>
         <profile>

--- a/src/main/java/com/kttdevelopment/mal4j/ExperimentalFeatureException.java
+++ b/src/main/java/com/kttdevelopment/mal4j/ExperimentalFeatureException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021-2022 Katsute <https://github.com/Katsute>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.kttdevelopment.mal4j;
+
+import com.kttdevelopment.mal4j.property.ExperimentalFeature;
+
+/**
+ * Thrown if an experimental feature is used without enabling it.
+ *
+ * @see ExperimentalFeature
+ * @see MyAnimeList#enableExperimentalFeature(ExperimentalFeature)
+ * @since 2.11.0
+ * @version 2.11.0
+ * @author Katsute
+ */
+public final class ExperimentalFeatureException extends RuntimeException {
+
+    ExperimentalFeatureException(final String message){
+        super(message);
+    }
+
+}

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -110,6 +110,10 @@ final class MyAnimeListImpl extends MyAnimeList {
             enabledFeatures.add(feature);
     }
 
+    final void clearExperimentalFeatures(){
+        enabledFeatures.clear();
+    }
+
 // provider
 
     @Override

--- a/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/mal4j/MyAnimeListImpl.java
@@ -99,8 +99,7 @@ final class MyAnimeListImpl extends MyAnimeList {
         if(nativeFeatures.contains(feature) || enabledFeatures.contains(feature) || enabledFeatures.contains(ExperimentalFeature.ALL))
             return;
 
-        // in the future this should throw an exception
-        Logging.getLogger().warning("The feature " + feature.name() + " is an experimental feature and should be enabled using the enableExperimentalFeature method. In the future an exception will be thrown if you use an experimental feature without enabling it");
+        throw new ExperimentalFeatureException("The feature " + feature.name() + " is an experimental feature and must be enabled using the enableExperimentalFeature method");
     }
 
     @Override

--- a/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/mal4j/AnimeTests/TestAnime.java
@@ -6,6 +6,7 @@ import com.kttdevelopment.mal4j.anime.RelatedAnime;
 import com.kttdevelopment.mal4j.anime.property.AnimeSource;
 import com.kttdevelopment.mal4j.anime.property.AnimeType;
 import com.kttdevelopment.mal4j.manga.RelatedManga;
+import com.kttdevelopment.mal4j.property.ExperimentalFeature;
 import com.kttdevelopment.mal4j.property.RelationType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +27,9 @@ final class TestAnime {
     @BeforeAll
     static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
+
+        mal.enableExperimentalFeature(ExperimentalFeature.ALL);
+
         anime = mal.getAnime(TestProvider.AltAnimeID, Fields.anime);
     }
 

--- a/src/test/java/com/kttdevelopment/mal4j/TestExperimentalEnabler.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestExperimentalEnabler.java
@@ -21,23 +21,21 @@ public class TestExperimentalEnabler {
 
     @Test @Order(0)
     public void testExperimental(){
-        anime.getOpeningThemes();
+        Assertions.assertThrows(ExperimentalFeatureException.class, anime::getOpeningThemes);
     }
 
     @Test @Order(1)
     public void testExperimentalEnabled(){
         mal.enableExperimentalFeature(ExperimentalFeature.OP_ED_THEMES);
 
-        anime.getOpeningThemes();
+        Assertions.assertDoesNotThrow(anime::getOpeningThemes);
     }
 
     @Test @Order(2)
     public void testExperimentalAllEnabled(){
         mal.enableExperimentalFeature(ExperimentalFeature.ALL);
 
-        anime.getVideos();
+        Assertions.assertDoesNotThrow(anime::getVideos);
     }
-
-    // todo: add test cases for when an experimental feature becomes native
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/TestExperimentalEnabler.java
+++ b/src/test/java/com/kttdevelopment/mal4j/TestExperimentalEnabler.java
@@ -15,6 +15,7 @@ public class TestExperimentalEnabler {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
+        ((MyAnimeListImpl) mal).clearExperimentalFeatures();
 
         anime = mal.getAnime(TestProvider.AnimeID);
     }
@@ -37,5 +38,7 @@ public class TestExperimentalEnabler {
 
         Assertions.assertDoesNotThrow(anime::getVideos);
     }
+
+    // todo: add test cases for when an experimental feature becomes native
 
 }

--- a/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/mal4j/UserTests/TestUser.java
@@ -1,6 +1,7 @@
 package com.kttdevelopment.mal4j.UserTests;
 
 import com.kttdevelopment.mal4j.*;
+import com.kttdevelopment.mal4j.property.ExperimentalFeature;
 import com.kttdevelopment.mal4j.user.User;
 import com.kttdevelopment.mal4j.user.property.AnimeAffinity;
 import com.kttdevelopment.mal4j.user.property.MangaAffinity;
@@ -30,6 +31,9 @@ final class TestUser {
     static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
         TestProvider.requireToken();
+
+        mal.enableExperimentalFeature(ExperimentalFeature.ALL);
+
         user = mal.getAuthenticatedUser(Fields.user);
     }
 


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Throw exception if experimental feature is used without enabling

[WF-3109844729](https://github.com/KatsuteDev/Mal4J/actions/runs/3109844729)

#### Release Notes

* Using an experimental feature without enabling it will throw a `ExperimentalFeatureException`, previously would only print a warning