### PR TITLE
Added getID method for RelatedAnime objects

### DIFF
--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
@@ -906,11 +906,15 @@ abstract class MyAnimeListSchema_Anime extends MyAnimeListSchema {
         return schema == null ? null : new RelatedAnime() {
 
             private final Anime anime                   = asAnimePreview(mal, schema.getJsonObject("node"));
+            private final Long id						= anime.getID();
             private final String relationType           = schema.getString("relation_type");
             private final RelationType e_relationType   = RelationType.asEnum(relationType);
             private final String relationTypeFormatted  = schema.getString("relation_type_formatted");
 
             // API methods
+            public final Long getID(){
+                return id;
+            }
 
             @Override
             public final RelationType getRelationType() {

--- a/src/main/java/dev/katsute/mal4j/anime/RelatedAnime.java
+++ b/src/main/java/dev/katsute/mal4j/anime/RelatedAnime.java
@@ -20,6 +20,7 @@ package dev.katsute.mal4j.anime;
 
 import dev.katsute.mal4j.anime.property.AnimeRetrievable;
 import dev.katsute.mal4j.manga.Manga;
+import dev.katsute.mal4j.property.ID;
 import dev.katsute.mal4j.property.RelatedMedia;
 
 /**
@@ -33,6 +34,6 @@ import dev.katsute.mal4j.property.RelatedMedia;
  * @version 2.12.0
  * @author Katsute
  */
-public abstract class RelatedAnime extends RelatedMedia implements AnimeRetrievable {
+public abstract class RelatedAnime extends RelatedMedia implements AnimeRetrievable, ID {
 
 }


### PR DESCRIPTION
Added a direct way to get the ID of an anime from it's related array object. Previously needed to call getAnime() then Anime object getID()

### Prerequisites
*Issues must meet the following criteria:*

 - [ ] No similar pull request exists.
 - [ ] Code follows the general code style of this project.
 - [ ] No sensitive information is exposed.
 - [ ] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [ ] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 -