### PR TITLE
Add ability to retrieve characters from Anime

### DIFF
--- a/.github/workflows/mal.yml
+++ b/.github/workflows/mal.yml
@@ -23,7 +23,7 @@ jobs:
             const comment = process.env.comment.split(' ');
 
             if(comment[0] == "mal")
-                core.exportVariable("url", comment[1]);
+              core.exportVariable("url", comment[1]);
 
       - name: cURL
         if: env.url
@@ -50,5 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT }}
           comment: ${{ env.comment }}
           number: ${{ github.event.issue.number }}
+          issue: ${{ github.event.issue && 'issue' || 'pr' }}
         run: |
-          gh issue comment $number -b "$comment"
+          gh $issue comment $number -b "$comment"

--- a/src/main/java/dev/katsute/mal4j/APIStruct.java
+++ b/src/main/java/dev/katsute/mal4j/APIStruct.java
@@ -18,11 +18,14 @@
 
 package dev.katsute.mal4j;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Annotations used to structure API calls.

--- a/src/main/java/dev/katsute/mal4j/Json.java
+++ b/src/main/java/dev/katsute/mal4j/Json.java
@@ -22,7 +22,9 @@ import dev.katsute.mal4j.exception.JsonSyntaxException;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.regex.*;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static dev.katsute.mal4j.Json.Expect.*;
 import static dev.katsute.mal4j.Json.Type.*;

--- a/src/main/java/dev/katsute/mal4j/Logging.java
+++ b/src/main/java/dev/katsute/mal4j/Logging.java
@@ -19,7 +19,10 @@
 package dev.katsute.mal4j;
 
 import java.util.HashSet;
-import java.util.logging.*;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * Used for logging operating.

--- a/src/main/java/dev/katsute/mal4j/MyAnimeList.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeList.java
@@ -177,6 +177,17 @@ public abstract class MyAnimeList {
      */
     public abstract Anime getAnime(final long id, final String... fields);
 
+    /**
+     * Returns characters for an Anime.
+     *
+     * @param id Anime id
+     * @return Anime character query
+     *
+     * @see AnimeCharacterQuery
+     * @since 3.1.0
+     */
+    public abstract AnimeCharacterQuery getAnimeCharacters(final long id);
+
 // anime ranking
 
     /**

--- a/src/main/java/dev/katsute/mal4j/MyAnimeList.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeList.java
@@ -184,6 +184,7 @@ public abstract class MyAnimeList {
      * @return Anime character query
      *
      * @see AnimeCharacterQuery
+     * @see Character
      * @since 3.1.0
      */
     public abstract AnimeCharacterQuery getAnimeCharacters(final long id);

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListAuthenticationService.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListAuthenticationService.java
@@ -19,7 +19,7 @@
 package dev.katsute.mal4j;
 
 import static dev.katsute.mal4j.APIStruct.*;
-import static dev.katsute.mal4j.Json.*;
+import static dev.katsute.mal4j.Json.JsonObject;
 
 /**
  * Represents the HTTP requests for authentication.

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListAuthenticator.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListAuthenticator.java
@@ -18,22 +18,34 @@
 
 package dev.katsute.mal4j;
 
-import com.sun.net.httpserver.*;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import dev.katsute.mal4j.APIStruct.Response;
-import dev.katsute.mal4j.exception.*;
+import dev.katsute.mal4j.exception.HttpException;
+import dev.katsute.mal4j.exception.InvalidTokenException;
+import dev.katsute.mal4j.exception.UnauthorizedAccessException;
 
 import java.awt.*;
 import java.io.IOException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
-import java.util.*;
-import java.util.concurrent.*;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.zip.GZIPOutputStream;
 
-import static dev.katsute.mal4j.Json.*;
+import static dev.katsute.mal4j.Json.JsonObject;
 
 /**
  * <b>Documentation:</b> <a href="https://myanimelist.net/apiconfig/references/authorization">https://myanimelist.net/apiconfig/references/authorization</a> <br>

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListImpl.java
@@ -177,6 +177,52 @@ final class MyAnimeListImpl extends MyAnimeList {
     }
 
     @Override
+    public final AnimeCharacterQuery getAnimeCharacters(final long id){
+        checkExperimentalFeatureEnabled(ExperimentalFeature.CHARACTERS);
+        return new AnimeCharacterQuery() {
+
+            @Override
+            public final List<Character> search(){
+                final JsonObject response = handleResponse(
+                    () -> service.getAnimeCharacters(
+                        isTokenAuth ? token : null,
+                        !isTokenAuth ? client_id : null,
+                        id,
+                        limit,
+                        offset,
+                        convertFields(Fields.character, (String[]) null)
+                    )
+                );
+                if(response == null) return null;
+
+                final List<Character> characters = new ArrayList<>();
+                final JsonObject[] arr = response.getJsonArray("data");
+                if(arr == null) return null;
+                for(final JsonObject iterator : arr)
+                    characters.add(MyAnimeListSchema_Character.asCharacter(MyAnimeListImpl.this, iterator.getJsonObject("node")));
+                return characters;
+            }
+
+            @Override
+            public final PaginatedIterator<Character> searchAll(){
+                return new PagedIterator<>(
+                    offset,
+                    offset -> service.getAnimeCharacters(
+                        isTokenAuth ? token : null,
+                        !isTokenAuth ? client_id : null,
+                        id,
+                        limit,
+                        offset,
+                        convertFields(Fields.character, (String[]) null)
+                    ),
+                    iterator -> MyAnimeListSchema_Character.asCharacter(MyAnimeListImpl.this, iterator.getJsonObject("node"))
+                );
+            }
+
+        };
+    }
+
+    @Override
     public final AnimeRankingQuery getAnimeRanking(final AnimeRankingType rankingType){
         return getAnimeRanking(Objects.requireNonNull(rankingType, "Ranking type cannot be null").field());
     }

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListImpl.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListImpl.java
@@ -19,13 +19,22 @@
 package dev.katsute.mal4j;
 
 import dev.katsute.mal4j.APIStruct.Response;
-import dev.katsute.mal4j.anime.*;
+import dev.katsute.mal4j.anime.Anime;
+import dev.katsute.mal4j.anime.AnimeListStatus;
+import dev.katsute.mal4j.anime.AnimeRanking;
 import dev.katsute.mal4j.anime.property.AnimeRankingType;
 import dev.katsute.mal4j.anime.property.time.Season;
 import dev.katsute.mal4j.character.Character;
-import dev.katsute.mal4j.exception.*;
-import dev.katsute.mal4j.forum.*;
-import dev.katsute.mal4j.manga.*;
+import dev.katsute.mal4j.exception.ExperimentalFeatureException;
+import dev.katsute.mal4j.exception.HttpException;
+import dev.katsute.mal4j.exception.InvalidTokenException;
+import dev.katsute.mal4j.forum.ForumCategory;
+import dev.katsute.mal4j.forum.ForumTopic;
+import dev.katsute.mal4j.forum.ForumTopicDetail;
+import dev.katsute.mal4j.forum.Post;
+import dev.katsute.mal4j.manga.Manga;
+import dev.katsute.mal4j.manga.MangaListStatus;
+import dev.katsute.mal4j.manga.MangaRanking;
 import dev.katsute.mal4j.manga.property.MangaRankingType;
 import dev.katsute.mal4j.property.ExperimentalFeature;
 import dev.katsute.mal4j.query.*;
@@ -34,17 +43,20 @@ import dev.katsute.mal4j.user.User;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
-import static dev.katsute.mal4j.Json.*;
+import static dev.katsute.mal4j.Json.JsonObject;
 import static dev.katsute.mal4j.MyAnimeListSchema_Anime.*;
-import static dev.katsute.mal4j.MyAnimeListSchema_Character.*;
+import static dev.katsute.mal4j.MyAnimeListSchema_Character.asCharacter;
 import static dev.katsute.mal4j.MyAnimeListSchema_Forum.*;
 import static dev.katsute.mal4j.MyAnimeListSchema_Manga.*;
-import static dev.katsute.mal4j.MyAnimeListSchema_User.*;
+import static dev.katsute.mal4j.MyAnimeListSchema_User.asUser;
 
 final class MyAnimeListImpl extends MyAnimeList {
 
@@ -190,7 +202,7 @@ final class MyAnimeListImpl extends MyAnimeList {
                         id,
                         limit,
                         offset,
-                        convertFields(Fields.character, (String[]) null)
+                        convertFields(Fields.character, fields)
                     )
                 );
                 if(response == null) return null;
@@ -213,7 +225,7 @@ final class MyAnimeListImpl extends MyAnimeList {
                         id,
                         limit,
                         offset,
-                        convertFields(Fields.character, (String[]) null)
+                        convertFields(Fields.character, fields)
                     ),
                     iterator -> MyAnimeListSchema_Character.asCharacter(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
@@ -21,7 +21,6 @@ import dev.katsute.mal4j.Json.JsonObject;
 import dev.katsute.mal4j.anime.*;
 import dev.katsute.mal4j.anime.property.*;
 import dev.katsute.mal4j.anime.property.time.*;
-import dev.katsute.mal4j.character.Character;
 import dev.katsute.mal4j.manga.RelatedManga;
 import dev.katsute.mal4j.property.*;
 import dev.katsute.mal4j.query.AnimeCharacterQuery;

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
@@ -21,8 +21,10 @@ import dev.katsute.mal4j.Json.JsonObject;
 import dev.katsute.mal4j.anime.*;
 import dev.katsute.mal4j.anime.property.*;
 import dev.katsute.mal4j.anime.property.time.*;
+import dev.katsute.mal4j.character.Character;
 import dev.katsute.mal4j.manga.RelatedManga;
 import dev.katsute.mal4j.property.*;
+import dev.katsute.mal4j.query.AnimeCharacterQuery;
 import dev.katsute.mal4j.query.AnimeListUpdate;
 
 import java.util.*;
@@ -631,6 +633,12 @@ abstract class MyAnimeListSchema_Anime extends MyAnimeListSchema {
                     ((MyAnimeListImpl) mal).checkExperimentalFeatureEnabled(ExperimentalFeature.VIDEOS);
                 if(!isFull) populate();
                 return videos != null ? Arrays.copyOf(videos, videos.length) : null;
+            }
+
+            @Override
+            public final AnimeCharacterQuery getCharacters(){
+                ((MyAnimeListImpl) mal).checkExperimentalFeatureEnabled(ExperimentalFeature.CHARACTERS);
+                return mal.getAnimeCharacters(id);
             }
 
             // additional methods

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Anime.java
@@ -20,13 +20,17 @@ package dev.katsute.mal4j;
 import dev.katsute.mal4j.Json.JsonObject;
 import dev.katsute.mal4j.anime.*;
 import dev.katsute.mal4j.anime.property.*;
-import dev.katsute.mal4j.anime.property.time.*;
+import dev.katsute.mal4j.anime.property.time.DayOfWeek;
+import dev.katsute.mal4j.anime.property.time.Season;
+import dev.katsute.mal4j.anime.property.time.Time;
 import dev.katsute.mal4j.manga.RelatedManga;
 import dev.katsute.mal4j.property.*;
 import dev.katsute.mal4j.query.AnimeCharacterQuery;
 import dev.katsute.mal4j.query.AnimeListUpdate;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Objects;
 
 @SuppressWarnings("unused")
 abstract class MyAnimeListSchema_Anime extends MyAnimeListSchema {
@@ -636,7 +640,6 @@ abstract class MyAnimeListSchema_Anime extends MyAnimeListSchema {
 
             @Override
             public final AnimeCharacterQuery getCharacters(){
-                ((MyAnimeListImpl) mal).checkExperimentalFeatureEnabled(ExperimentalFeature.CHARACTERS);
                 return mal.getAnimeCharacters(id);
             }
 

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Common.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Common.java
@@ -17,7 +17,9 @@
  */
 package dev.katsute.mal4j;
 
-import dev.katsute.mal4j.property.*;
+import dev.katsute.mal4j.property.AlternativeTitles;
+import dev.katsute.mal4j.property.Genre;
+import dev.katsute.mal4j.property.Picture;
 
 import java.util.Arrays;
 import java.util.Objects;

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Forum.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Forum.java
@@ -19,7 +19,10 @@ package dev.katsute.mal4j;
 
 import dev.katsute.mal4j.Json.JsonObject;
 import dev.katsute.mal4j.forum.*;
-import dev.katsute.mal4j.forum.property.*;
+import dev.katsute.mal4j.forum.property.ForumTopicCreator;
+import dev.katsute.mal4j.forum.property.Poll;
+import dev.katsute.mal4j.forum.property.PollOption;
+import dev.katsute.mal4j.forum.property.PostAuthor;
 import dev.katsute.mal4j.user.User;
 
 import java.util.Arrays;

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Manga.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_Manga.java
@@ -24,7 +24,9 @@ import dev.katsute.mal4j.manga.property.*;
 import dev.katsute.mal4j.property.*;
 import dev.katsute.mal4j.query.MangaListUpdate;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Objects;
 
 @SuppressWarnings("unused")
 abstract class MyAnimeListSchema_Manga extends MyAnimeListSchema {

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_User.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListSchema_User.java
@@ -27,7 +27,10 @@ import dev.katsute.mal4j.query.UserAnimeListQuery;
 import dev.katsute.mal4j.query.UserMangaListQuery;
 import dev.katsute.mal4j.user.User;
 import dev.katsute.mal4j.user.UserAnimeStatistics;
-import dev.katsute.mal4j.user.property.*;
+import dev.katsute.mal4j.user.property.AffinityAlgorithm;
+import dev.katsute.mal4j.user.property.AnimeAffinity;
+import dev.katsute.mal4j.user.property.MangaAffinity;
+import dev.katsute.mal4j.user.property.MyAnimeListAffinityAlgorithm;
 
 import java.util.*;
 import java.util.function.Consumer;

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListService.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListService.java
@@ -19,7 +19,7 @@
 package dev.katsute.mal4j;
 
 import static dev.katsute.mal4j.APIStruct.*;
-import static dev.katsute.mal4j.Json.*;
+import static dev.katsute.mal4j.Json.JsonObject;
 
 /**
  * Represents the HTTP requests for MyAnimeList.

--- a/src/main/java/dev/katsute/mal4j/MyAnimeListService.java
+++ b/src/main/java/dev/katsute/mal4j/MyAnimeListService.java
@@ -56,6 +56,16 @@ interface MyAnimeListService {
         @Query(value = "fields", encoded = true)    final String fields
     );
 
+    @Endpoint(method="GET", value="anime/{anime_id}/characters")
+    Response<JsonObject> getAnimeCharacters(
+        @Header("Authorization")                    final String token,
+        @Header("X-MAL-CLIENT-ID")                  final String client_id,
+        @Path(value = "anime_id")                   final Long anime_id,
+        @Query("limit")                             final Integer limit,
+        @Query("offset")                            final Integer offset,
+        @Query(value = "fields", encoded = true)    final String fields
+    );
+
     @Endpoint(method="GET", value="anime/ranking")
     Response<JsonObject> getAnimeRanking(
         @Header("Authorization")                    final String token,

--- a/src/main/java/dev/katsute/mal4j/anime/Anime.java
+++ b/src/main/java/dev/katsute/mal4j/anime/Anime.java
@@ -19,7 +19,9 @@
 package dev.katsute.mal4j.anime;
 
 import dev.katsute.mal4j.anime.property.*;
+import dev.katsute.mal4j.character.Character;
 import dev.katsute.mal4j.property.FullMediaItem;
+import dev.katsute.mal4j.query.AnimeCharacterQuery;
 
 /**
  * <b>Documentation:</b> <a href="https://myanimelist.net/apiconfig/references/api/v2#operation/anime_anime_id_get">https://myanimelist.net/apiconfig/references/api/v2#operation/anime_anime_id_get</a> <br>
@@ -64,5 +66,16 @@ public abstract class Anime extends AnimePreview implements FullMediaItem<AnimeT
      * @since 2.10.0
      */
     public abstract Video[] getVideos();
+
+    /**
+     * Returns characters.
+     *
+     * @return characters
+     *
+     * @see Character
+     * @see AnimeCharacterQuery
+     * @since 3.1.0
+     */
+    public abstract AnimeCharacterQuery getCharacters();
 
 }

--- a/src/main/java/dev/katsute/mal4j/anime/AnimeListStatus.java
+++ b/src/main/java/dev/katsute/mal4j/anime/AnimeListStatus.java
@@ -19,7 +19,9 @@
 package dev.katsute.mal4j.anime;
 
 import dev.katsute.mal4j.MyAnimeList;
-import dev.katsute.mal4j.anime.property.*;
+import dev.katsute.mal4j.anime.property.AnimeRetrievable;
+import dev.katsute.mal4j.anime.property.AnimeStatus;
+import dev.katsute.mal4j.anime.property.RewatchValue;
 import dev.katsute.mal4j.property.Editable;
 import dev.katsute.mal4j.property.ListStatus;
 import dev.katsute.mal4j.query.AnimeListUpdate;

--- a/src/main/java/dev/katsute/mal4j/character/package-info.java
+++ b/src/main/java/dev/katsute/mal4j/character/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains {@link dev.katsute.mal4j.character.Character} classes.
+ */
+package dev.katsute.mal4j.character;

--- a/src/main/java/dev/katsute/mal4j/manga/Manga.java
+++ b/src/main/java/dev/katsute/mal4j/manga/Manga.java
@@ -18,7 +18,10 @@
 
 package dev.katsute.mal4j.manga;
 
-import dev.katsute.mal4j.manga.property.*;
+import dev.katsute.mal4j.manga.property.MangaPublishStatus;
+import dev.katsute.mal4j.manga.property.MangaStatistics;
+import dev.katsute.mal4j.manga.property.MangaType;
+import dev.katsute.mal4j.manga.property.Publisher;
 import dev.katsute.mal4j.property.FullMediaItem;
 
 /**

--- a/src/main/java/dev/katsute/mal4j/manga/MangaListStatus.java
+++ b/src/main/java/dev/katsute/mal4j/manga/MangaListStatus.java
@@ -19,7 +19,9 @@
 package dev.katsute.mal4j.manga;
 
 import dev.katsute.mal4j.MyAnimeList;
-import dev.katsute.mal4j.manga.property.*;
+import dev.katsute.mal4j.manga.property.MangaRetrievable;
+import dev.katsute.mal4j.manga.property.MangaStatus;
+import dev.katsute.mal4j.manga.property.RereadValue;
 import dev.katsute.mal4j.property.Editable;
 import dev.katsute.mal4j.property.ListStatus;
 import dev.katsute.mal4j.query.MangaListUpdate;

--- a/src/main/java/dev/katsute/mal4j/manga/MangaPreview.java
+++ b/src/main/java/dev/katsute/mal4j/manga/MangaPreview.java
@@ -19,7 +19,9 @@
 package dev.katsute.mal4j.manga;
 
 import dev.katsute.mal4j.MyAnimeList;
-import dev.katsute.mal4j.manga.property.*;
+import dev.katsute.mal4j.manga.property.Author;
+import dev.katsute.mal4j.manga.property.MangaPublishStatus;
+import dev.katsute.mal4j.manga.property.MangaType;
 import dev.katsute.mal4j.property.MediaItem;
 
 /**

--- a/src/main/java/dev/katsute/mal4j/query/AnimeCharacterQuery.java
+++ b/src/main/java/dev/katsute/mal4j/query/AnimeCharacterQuery.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Katsute <https://github.com/Katsute>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package dev.katsute.mal4j.query;
+
+import dev.katsute.mal4j.anime.Anime;
+import dev.katsute.mal4j.character.Character;
+
+/**
+ * Represents a Anime character query.
+ *
+ * @see Anime#getCharacters()
+ * @see LimitOffsetQuery
+ * @since 3.1.0
+ * @version 3.1.0
+ * @author Katsute
+ */
+public abstract class AnimeCharacterQuery extends LimitOffsetQuery<AnimeCharacterQuery,Character> {
+
+    /**
+     * Creates an Anime character query.
+     * <br>
+     * Do not use this constructor, use {@link Anime#getCharacters()}
+     *
+     * @see Anime#getCharacters()
+     * @since 3.1.0
+     */
+    public AnimeCharacterQuery(){ }
+
+}

--- a/src/main/java/dev/katsute/mal4j/query/AnimeCharacterQuery.java
+++ b/src/main/java/dev/katsute/mal4j/query/AnimeCharacterQuery.java
@@ -24,19 +24,21 @@ import dev.katsute.mal4j.character.Character;
 /**
  * Represents a Anime character query.
  *
+ * @see dev.katsute.mal4j.MyAnimeList#getAnimeCharacters(long)
  * @see Anime#getCharacters()
  * @see LimitOffsetQuery
  * @since 3.1.0
  * @version 3.1.0
  * @author Katsute
  */
-public abstract class AnimeCharacterQuery extends LimitOffsetQuery<AnimeCharacterQuery,Character> {
+public abstract class AnimeCharacterQuery extends FieldQuery<AnimeCharacterQuery,Character> {
 
     /**
      * Creates an Anime character query.
      * <br>
-     * Do not use this constructor, use {@link Anime#getCharacters()}
+     * Do not use this constructor, use {@link dev.katsute.mal4j.MyAnimeList#getAnimeCharacters(long)} or {@link Anime#getCharacters()} instead.
      *
+     * @see dev.katsute.mal4j.MyAnimeList#getAnimeCharacters(long)
      * @see Anime#getCharacters()
      * @since 3.1.0
      */

--- a/src/main/java/dev/katsute/mal4j/query/FieldQuery.java
+++ b/src/main/java/dev/katsute/mal4j/query/FieldQuery.java
@@ -20,7 +20,9 @@ package dev.katsute.mal4j.query;
 
 import dev.katsute.mal4j.Fields;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Represents a field query. Returns all fields by default.

--- a/src/main/java/dev/katsute/mal4j/query/ListUpdate.java
+++ b/src/main/java/dev/katsute/mal4j/query/ListUpdate.java
@@ -18,9 +18,14 @@
 
 package dev.katsute.mal4j.query;
 
-import dev.katsute.mal4j.property.*;
+import dev.katsute.mal4j.property.FieldEnum;
+import dev.katsute.mal4j.property.ListStatus;
+import dev.katsute.mal4j.property.Priority;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
 
 /**
  * Represents a list update.

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnime.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnime.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.AnimeTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.Anime;
 import dev.katsute.mal4j.anime.RelatedAnime;
 import dev.katsute.mal4j.anime.property.AnimeSource;
@@ -8,7 +10,10 @@ import dev.katsute.mal4j.anime.property.AnimeType;
 import dev.katsute.mal4j.manga.RelatedManga;
 import dev.katsute.mal4j.property.ExperimentalFeature;
 import dev.katsute.mal4j.property.RelationType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeListStatus.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.AnimeTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.AnimeListStatus;
 import dev.katsute.mal4j.anime.property.AnimeStatus;
 import dev.katsute.mal4j.anime.property.RewatchValue;
@@ -12,7 +14,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeListStatusUsername.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeListStatusUsername.java
@@ -1,13 +1,15 @@
 package dev.katsute.mal4j.AnimeTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.AnimeListStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 final class TestAnimeListStatusUsername {
 

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeRank.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeRank.java
@@ -1,15 +1,19 @@
 package dev.katsute.mal4j.AnimeTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.AnimeRanking;
 import dev.katsute.mal4j.anime.property.AnimeRankingType;
 import dev.katsute.mal4j.anime.property.AnimeType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 final class TestAnimeRank {
 

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeSeason.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeSeason.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.AnimeTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.Anime;
 import dev.katsute.mal4j.anime.property.AnimeSeasonSort;
 import dev.katsute.mal4j.anime.property.time.Season;
@@ -10,7 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class TestAnimeSeason {
 

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeSuggestions.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestAnimeSuggestions.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 final class TestAnimeSuggestions {
 

--- a/src/test/java/dev/katsute/mal4j/AnimeTests/TestUserAnimeListing.java
+++ b/src/test/java/dev/katsute/mal4j/AnimeTests/TestUserAnimeListing.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.AnimeTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.AnimeListStatus;
 import dev.katsute.mal4j.anime.property.AnimeSort;
 import dev.katsute.mal4j.anime.property.AnimeStatus;
@@ -9,7 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class TestUserAnimeListing {
 

--- a/src/test/java/dev/katsute/mal4j/CharacterTests/TestAnimeCharacter.java
+++ b/src/test/java/dev/katsute/mal4j/CharacterTests/TestAnimeCharacter.java
@@ -1,0 +1,48 @@
+package dev.katsute.mal4j.CharacterTests;
+
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
+import dev.katsute.mal4j.character.Character;
+import dev.katsute.mal4j.property.ExperimentalFeature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class TestAnimeCharacter {
+
+    private static MyAnimeList mal;
+
+    @SuppressWarnings({"ConstantConditions", "RedundantSuppression"})
+    @BeforeAll
+    static void beforeAll(){
+        mal = TestProvider.getMyAnimeList();
+
+        mal.enableExperimentalFeature(ExperimentalFeature.CHARACTERS);
+    }
+
+    @Test
+    final void testCharacter(){
+        final List<Character> characters = mal.getAnimeCharacters(TestProvider.AnimeID)
+            .withLimit(100)
+            .withNoFields()
+            .search();
+
+        assertNotNull(characters);
+        assertFalse(characters.isEmpty());
+
+        for(final Character character : characters)
+            if(character.getID() == TestProvider.CharacterID)
+                return;
+        fail("Failed to find character in list");
+    }
+
+    @Test
+    final void testFields(){
+        assertNull(mal.getAnimeCharacters(TestProvider.AnimeID).withNoFields().search().get(0).getFirstName());
+        assertNotNull(mal.getAnimeCharacters(TestProvider.AnimeID).withAllFields().search().get(0).getFirstName());
+    }
+
+}

--- a/src/test/java/dev/katsute/mal4j/ForumTests/TestForumCategories.java
+++ b/src/test/java/dev/katsute/mal4j/ForumTests/TestForumCategories.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 final class TestForumCategories {
 

--- a/src/test/java/dev/katsute/mal4j/ForumTests/TestForumTopics.java
+++ b/src/test/java/dev/katsute/mal4j/ForumTests/TestForumTopics.java
@@ -3,11 +3,15 @@ package dev.katsute.mal4j.ForumTests;
 import dev.katsute.mal4j.MyAnimeList;
 import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.forum.ForumTopic;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 final class TestForumTopics {
 

--- a/src/test/java/dev/katsute/mal4j/MangaTests/TestManga.java
+++ b/src/test/java/dev/katsute/mal4j/MangaTests/TestManga.java
@@ -1,11 +1,16 @@
 package dev.katsute.mal4j.MangaTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.anime.RelatedAnime;
 import dev.katsute.mal4j.manga.Manga;
 import dev.katsute.mal4j.manga.property.MangaPublishStatus;
 import dev.katsute.mal4j.manga.property.MangaType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -14,7 +19,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 final class TestManga {
 

--- a/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaListStatus.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.MangaTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.manga.MangaListStatus;
 import dev.katsute.mal4j.manga.property.MangaStatus;
 import dev.katsute.mal4j.manga.property.RereadValue;
@@ -12,10 +14,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 final class TestMangaListStatus {

--- a/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaListStatusUsername.java
+++ b/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaListStatusUsername.java
@@ -1,13 +1,15 @@
 package dev.katsute.mal4j.MangaTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.manga.MangaListStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 final class TestMangaListStatusUsername {
 

--- a/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaRank.java
+++ b/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaRank.java
@@ -1,15 +1,19 @@
 package dev.katsute.mal4j.MangaTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.manga.MangaRanking;
 import dev.katsute.mal4j.manga.property.MangaRankingType;
 import dev.katsute.mal4j.manga.property.MangaType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 final class TestMangaRank {
 

--- a/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaSearch.java
+++ b/src/test/java/dev/katsute/mal4j/MangaTests/TestMangaSearch.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 final class TestMangaSearch {
 

--- a/src/test/java/dev/katsute/mal4j/MangaTests/TestUserMangaListing.java
+++ b/src/test/java/dev/katsute/mal4j/MangaTests/TestUserMangaListing.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.MangaTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.manga.MangaListStatus;
 import dev.katsute.mal4j.manga.property.MangaSort;
 import dev.katsute.mal4j.manga.property.MangaStatus;
@@ -9,7 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class TestUserMangaListing {
 

--- a/src/test/java/dev/katsute/mal4j/TestAPICall.java
+++ b/src/test/java/dev/katsute/mal4j/TestAPICall.java
@@ -1,7 +1,9 @@
 package dev.katsute.mal4j;
 
 import com.sun.net.httpserver.HttpServer;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.InetSocketAddress;

--- a/src/test/java/dev/katsute/mal4j/TestIterator.java
+++ b/src/test/java/dev/katsute/mal4j/TestIterator.java
@@ -5,7 +5,8 @@ import dev.katsute.mal4j.forum.Post;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 final class TestIterator {
 

--- a/src/test/java/dev/katsute/mal4j/TestJson.java
+++ b/src/test/java/dev/katsute/mal4j/TestJson.java
@@ -4,7 +4,9 @@ import dev.katsute.mal4j.exception.JsonSyntaxException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,7 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static dev.katsute.mal4j.Json.*;
+import static dev.katsute.mal4j.Json.JsonObject;
+import static dev.katsute.mal4j.Json.parse;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("SpellCheckingInspection")

--- a/src/test/java/dev/katsute/mal4j/TestMyAnimeList.java
+++ b/src/test/java/dev/katsute/mal4j/TestMyAnimeList.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final class TestMyAnimeList {
 

--- a/src/test/java/dev/katsute/mal4j/TestPreview.java
+++ b/src/test/java/dev/katsute/mal4j/TestPreview.java
@@ -4,7 +4,9 @@ import dev.katsute.mal4j.anime.Anime;
 import dev.katsute.mal4j.anime.property.AnimeRankingType;
 import dev.katsute.mal4j.manga.Manga;
 import dev.katsute.mal4j.manga.property.MangaRankingType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 final class TestPreview {
 

--- a/src/test/java/dev/katsute/mal4j/TestProvider.java
+++ b/src/test/java/dev/katsute/mal4j/TestProvider.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class TestProvider {
 
@@ -52,7 +52,7 @@ public abstract class TestProvider {
     // Character
 
     public static final long CharacterID = 61371;
-    public static final long AltCharacterID = 36828;
+    public static final long AltCharacterID = 36828; // for tests that require additional fields
     public static final long NSFW_CharacterID = 104119;
 
     //

--- a/src/test/java/dev/katsute/mal4j/TestREADME.java
+++ b/src/test/java/dev/katsute/mal4j/TestREADME.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j;
 
-import dev.katsute.mal4j.anime.*;
+import dev.katsute.mal4j.anime.Anime;
+import dev.katsute.mal4j.anime.AnimeRecommendation;
+import dev.katsute.mal4j.anime.RelatedAnime;
 import dev.katsute.mal4j.anime.property.OpeningTheme;
 import dev.katsute.mal4j.anime.property.Video;
 import dev.katsute.mal4j.character.Character;

--- a/src/test/java/dev/katsute/mal4j/TestRegex9.java
+++ b/src/test/java/dev/katsute/mal4j/TestRegex9.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final class TestRegex9 {
 

--- a/src/test/java/dev/katsute/mal4j/UserTests/TestAffinityAlgorithm.java
+++ b/src/test/java/dev/katsute/mal4j/UserTests/TestAffinityAlgorithm.java
@@ -10,7 +10,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final class TestAffinityAlgorithm {
 

--- a/src/test/java/dev/katsute/mal4j/UserTests/TestUser.java
+++ b/src/test/java/dev/katsute/mal4j/UserTests/TestUser.java
@@ -1,6 +1,8 @@
 package dev.katsute.mal4j.UserTests;
 
-import dev.katsute.mal4j.*;
+import dev.katsute.mal4j.Fields;
+import dev.katsute.mal4j.MyAnimeList;
+import dev.katsute.mal4j.TestProvider;
 import dev.katsute.mal4j.property.ExperimentalFeature;
 import dev.katsute.mal4j.user.User;
 import dev.katsute.mal4j.user.property.AnimeAffinity;
@@ -18,7 +20,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 final class TestUser {
 

--- a/src/test/java/dev/katsute/mal4j/auth/TestLocalServerRedirect.java
+++ b/src/test/java/dev/katsute/mal4j/auth/TestLocalServerRedirect.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static dev.katsute.mal4j.MyAnimeListAuthenticator.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static dev.katsute.mal4j.MyAnimeListAuthenticator.LocalServerBuilder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 final class TestLocalServerRedirect {
 

--- a/src/test/java/dev/katsute/mal4j/auth/TestLocalServerToken.java
+++ b/src/test/java/dev/katsute/mal4j/auth/TestLocalServerToken.java
@@ -1,14 +1,17 @@
 package dev.katsute.mal4j.auth;
 
 import dev.katsute.mal4j.*;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Objects;
 
-import static dev.katsute.mal4j.MyAnimeListAuthenticator.*;
+import static dev.katsute.mal4j.MyAnimeListAuthenticator.LocalServerBuilder;
 import static org.junit.jupiter.api.Assertions.*;
 
 public final class TestLocalServerToken {

--- a/src/test/java/dev/katsute/mal4j/auth/TestMyAnimeListAuthenticator.java
+++ b/src/test/java/dev/katsute/mal4j/auth/TestMyAnimeListAuthenticator.java
@@ -1,9 +1,14 @@
 package dev.katsute.mal4j.auth;
 
-import dev.katsute.mal4j.*;
-import org.junit.jupiter.api.*;
+import dev.katsute.mal4j.AccessToken;
+import dev.katsute.mal4j.Authorization;
+import dev.katsute.mal4j.MyAnimeListAuthenticator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
-import static dev.katsute.mal4j.MyAnimeListAuthenticator.*;
+import static dev.katsute.mal4j.MyAnimeListAuthenticator.generatePKCE;
+import static dev.katsute.mal4j.MyAnimeListAuthenticator.getAuthorizationURL;
 import static org.junit.jupiter.api.Assertions.*;
 
 final class TestMyAnimeListAuthenticator {


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### Code Generators
*The use of GitHub Copilot or ChatGPT is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot or ChatGPT.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Add method to retrieve characters for an Anime
 - Add missing character package info

https://github.com/KatsuteDev/Mal4J/actions/runs/5060396626

#### Release Notes

This is an undocumented feature, you must use `MyAnimeList.enableExperimentalFeature(ExperimentalFeature.CHARACTERS)` to enable it.

Retrieve characters using `MyAnimeList.getAnimeCharacters(anime id)` or `Anime.getCharacters()`.

Character information currently includes:

 * Name
 * Alternative names
 * Picture
 * Biography
 * Animeography